### PR TITLE
Add signature for Error.prepareStackTrace() to Node v4, 6, 7, 8

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -318,7 +318,7 @@ declare namespace NodeJS {
 
     export interface CallSite {
         getThis: Function; // returns the value of this
-        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getTypeName(): string; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function
         getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
         getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -50,7 +50,7 @@ interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
 
     // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
 
     stackTraceLimit: number;
 }
@@ -316,7 +316,7 @@ declare namespace NodeJS {
         new(stdout: WritableStream, stderr?: WritableStream): Console;
     }
 
-    export interface StackFrame {
+    export interface CallSite {
         getThis: Function; // returns the value of this
         getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -326,10 +326,10 @@ declare namespace NodeJS {
         getLineNumber: Function; // if this function was defined in a script returns the current line number
         getColumnNumber: Function; // if this function was defined in a script returns the current column number
         getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
-        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
-        isEval: boolean; // does this call take place in code defined by a call to eval?
-        isNative: boolean; // is this call in native V8 code?
-        isConstructor: boolean; // is this a constructor call?
+        isToplevel: Function; // is this a toplevel invocation, that is, is this the global object?
+        isEval: Function; // does this call take place in code defined by a call to eval?
+        isNative: Function; // is this call in native V8 code?
+        isConstructor: Function; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -45,8 +45,13 @@ interface Error {
     stack?: string;
 }
 
+// Declare "static" methods in Error
 interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+
+    // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+
     stackTraceLimit: number;
 }
 
@@ -309,6 +314,22 @@ declare namespace NodeJS {
     export interface ConsoleConstructor {
         prototype: Console;
         new(stdout: WritableStream, stderr?: WritableStream): Console;
+    }
+
+    export interface StackFrame {
+        getThis: Function; // returns the value of this
+        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getFunction: Function; // returns the current function
+        getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
+        getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function
+        getFileName: Function; // if this function was defined in a script returns the name of the script
+        getLineNumber: Function; // if this function was defined in a script returns the current line number
+        getColumnNumber: Function; // if this function was defined in a script returns the current column number
+        getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
+        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
+        isEval: boolean; // does this call take place in code defined by a call to eval?
+        isNative: boolean; // is this call in native V8 code?
+        isConstructor: boolean; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2429,6 +2429,10 @@ namespace errors_tests {
         let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
+    {
+        let frame: NodeJS.CallSite = null;
+        let typeName: string = frame.getTypeName();
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2425,6 +2425,10 @@ namespace errors_tests {
         const myObject = {};
         Error.captureStackTrace(myObject);
     }
+    {
+        let frames: NodeJS.StackFrame[] = [];
+        Error.prepareStackTrace(new Error(), frames);
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2426,7 +2426,7 @@ namespace errors_tests {
         Error.captureStackTrace(myObject);
     }
     {
-        let frames: NodeJS.StackFrame[] = [];
+        let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
 }

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -39,7 +39,7 @@ interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
 
     // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
 
     stackTraceLimit: number;
 }
@@ -234,7 +234,7 @@ declare namespace NodeJS {
         customInspect?: boolean;
     }
 
-    export interface StackFrame {
+    export interface CallSite {
         getThis: Function; // returns the value of this
         getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -244,10 +244,10 @@ declare namespace NodeJS {
         getLineNumber: Function; // if this function was defined in a script returns the current line number
         getColumnNumber: Function; // if this function was defined in a script returns the current column number
         getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
-        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
-        isEval: boolean; // does this call take place in code defined by a call to eval?
-        isNative: boolean; // is this call in native V8 code?
-        isConstructor: boolean; // is this a constructor call?
+        isToplevel: Function; // is this a toplevel invocation, that is, is this the global object?
+        isEval: Function; // does this call take place in code defined by a call to eval?
+        isNative: Function; // is this call in native V8 code?
+        isConstructor: Function; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -236,7 +236,7 @@ declare namespace NodeJS {
 
     export interface CallSite {
         getThis: Function; // returns the value of this
-        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getTypeName(): string; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function
         getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
         getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -34,8 +34,13 @@ interface Error {
     stack?: string;
 }
 
+// Declare "static" methods in Error
 interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+
+    // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+
     stackTraceLimit: number;
 }
 
@@ -227,6 +232,22 @@ declare namespace NodeJS {
         depth?: number | null;
         colors?: boolean;
         customInspect?: boolean;
+    }
+
+    export interface StackFrame {
+        getThis: Function; // returns the value of this
+        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getFunction: Function; // returns the current function
+        getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
+        getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function
+        getFileName: Function; // if this function was defined in a script returns the name of the script
+        getLineNumber: Function; // if this function was defined in a script returns the current line number
+        getColumnNumber: Function; // if this function was defined in a script returns the current column number
+        getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
+        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
+        isEval: boolean; // does this call take place in code defined by a call to eval?
+        isNative: boolean; // is this call in native V8 code?
+        isConstructor: boolean; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -1009,7 +1009,7 @@ namespace errors_tests {
         Error.captureStackTrace(myObject);
     }
     {
-        let frames: NodeJS.StackFrame[] = [];
+        let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
 }

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -1012,6 +1012,10 @@ namespace errors_tests {
         let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
+    {
+        let frame: NodeJS.CallSite = null;
+        let typeName: string = frame.getTypeName();
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -1008,6 +1008,10 @@ namespace errors_tests {
         const myObject = {};
         Error.captureStackTrace(myObject);
     }
+    {
+        let frames: NodeJS.StackFrame[] = [];
+        Error.prepareStackTrace(new Error(), frames);
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -31,8 +31,13 @@ interface Error {
     stack?: string;
 }
 
+// Declare "static" methods in Error
 interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+
+    // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+
     stackTraceLimit: number;
 }
 
@@ -256,6 +261,22 @@ declare namespace NodeJS {
     export var Console: {
         prototype: Console;
         new(stdout: WritableStream, stderr?: WritableStream): Console;
+    }
+
+    export interface StackFrame {
+        getThis: Function; // returns the value of this
+        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getFunction: Function; // returns the current function
+        getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
+        getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function
+        getFileName: Function; // if this function was defined in a script returns the name of the script
+        getLineNumber: Function; // if this function was defined in a script returns the current line number
+        getColumnNumber: Function; // if this function was defined in a script returns the current column number
+        getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
+        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
+        isEval: boolean; // does this call take place in code defined by a call to eval?
+        isNative: boolean; // is this call in native V8 code?
+        isConstructor: boolean; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -265,7 +265,7 @@ declare namespace NodeJS {
 
     export interface CallSite {
         getThis: Function; // returns the value of this
-        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getTypeName(): string; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function
         getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
         getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -36,7 +36,7 @@ interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
 
     // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
 
     stackTraceLimit: number;
 }
@@ -263,7 +263,7 @@ declare namespace NodeJS {
         new(stdout: WritableStream, stderr?: WritableStream): Console;
     }
 
-    export interface StackFrame {
+    export interface CallSite {
         getThis: Function; // returns the value of this
         getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -273,10 +273,10 @@ declare namespace NodeJS {
         getLineNumber: Function; // if this function was defined in a script returns the current line number
         getColumnNumber: Function; // if this function was defined in a script returns the current column number
         getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
-        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
-        isEval: boolean; // does this call take place in code defined by a call to eval?
-        isNative: boolean; // is this call in native V8 code?
-        isConstructor: boolean; // is this a constructor call?
+        isToplevel: Function; // is this a toplevel invocation, that is, is this the global object?
+        isEval: Function; // does this call take place in code defined by a call to eval?
+        isNative: Function; // is this call in native V8 code?
+        isConstructor: Function; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1833,6 +1833,10 @@ namespace errors_tests {
         let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
+    {
+        let frame: NodeJS.CallSite = null;
+        let typeName: string = frame.getTypeName();
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1830,7 +1830,7 @@ namespace errors_tests {
         Error.captureStackTrace(myObject);
     }
     {
-        let frames: NodeJS.StackFrame[] = [];
+        let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
 }

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1829,6 +1829,10 @@ namespace errors_tests {
         const myObject = {};
         Error.captureStackTrace(myObject);
     }
+    {
+        let frames: NodeJS.StackFrame[] = [];
+        Error.prepareStackTrace(new Error(), frames);
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -37,7 +37,7 @@ interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
 
     // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
-    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.CallSite[]) => any;
 
     stackTraceLimit: number;
 }
@@ -275,7 +275,7 @@ declare namespace NodeJS {
         new(stdout: WritableStream, stderr?: WritableStream): Console;
     }
 
-    export interface StackFrame {
+    export interface CallSite {
         getThis: Function; // returns the value of this
         getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -277,7 +277,7 @@ declare namespace NodeJS {
 
     export interface CallSite {
         getThis: Function; // returns the value of this
-        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getTypeName(): string; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
         getFunction: Function; // returns the current function
         getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
         getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -32,8 +32,13 @@ interface Error {
     stack?: string;
 }
 
+// Declare "static" methods in Error
 interface ErrorConstructor {
     captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+
+    // See https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
+    prepareStackTrace?: (err: Error, stackTraces: NodeJS.StackFrame[]) => any;
+
     stackTraceLimit: number;
 }
 
@@ -268,6 +273,22 @@ declare namespace NodeJS {
     export interface ConsoleConstructor {
         prototype: Console;
         new(stdout: WritableStream, stderr?: WritableStream): Console;
+    }
+
+    export interface StackFrame {
+        getThis: Function; // returns the value of this
+        getTypeName: Function; // returns the type of this as a string. This is the name of the function stored in the constructor field of this, if available, otherwise the object's [[Class]] internal property.
+        getFunction: Function; // returns the current function
+        getFunctionName: Function; // returns the name of the current function, typically its name property. If a name property is not available an attempt will be made to try to infer a name from the function's context.
+        getMethodName: Function; // returns the name of the property of this or one of its prototypes that holds the current function
+        getFileName: Function; // if this function was defined in a script returns the name of the script
+        getLineNumber: Function; // if this function was defined in a script returns the current line number
+        getColumnNumber: Function; // if this function was defined in a script returns the current column number
+        getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
+        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
+        isEval: boolean; // does this call take place in code defined by a call to eval?
+        isNative: boolean; // is this call in native V8 code?
+        isConstructor: boolean; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -285,10 +285,10 @@ declare namespace NodeJS {
         getLineNumber: Function; // if this function was defined in a script returns the current line number
         getColumnNumber: Function; // if this function was defined in a script returns the current column number
         getEvalOrigin: Function; // if this function was created using a call to eval returns a CallSite object representing the location where eval was called
-        isToplevel: boolean; // is this a toplevel invocation, that is, is this the global object?
-        isEval: boolean; // does this call take place in code defined by a call to eval?
-        isNative: boolean; // is this call in native V8 code?
-        isConstructor: boolean; // is this a constructor call?
+        isToplevel: Function; // is this a toplevel invocation, that is, is this the global object?
+        isEval: Function; // does this call take place in code defined by a call to eval?
+        isNative: Function; // is this call in native V8 code?
+        isConstructor: Function; // is this a constructor call?
     }
 
     export interface ErrnoException extends Error {

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -1931,6 +1931,10 @@ namespace errors_tests {
         const myObject = {};
         Error.captureStackTrace(myObject);
     }
+    {
+        let frames: NodeJS.StackFrame[] = [];
+        Error.prepareStackTrace(new Error(), frames);
+    }
 }
 
 ///////////////////////////////////////////////////////////

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -1932,7 +1932,7 @@ namespace errors_tests {
         Error.captureStackTrace(myObject);
     }
     {
-        let frames: NodeJS.StackFrame[] = [];
+        let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
 }

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -1935,6 +1935,10 @@ namespace errors_tests {
         let frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
+    {
+        let frame: NodeJS.CallSite = null;
+        let typeName: string = frame.getTypeName();
+    }
 }
 
 ///////////////////////////////////////////////////////////


### PR DESCRIPTION
# GrabCAD notes

https://grabcad.atlassian.net/browse/GC-42917

This internal PR is to merge the branch into master on the _fork_.
There will be an future/public PR to move the changes from the _fork_ back upstream to the official DefinitelyTyped repo.

The changes to v4, 6, 7, 8 are all identical across all versions (add to ErrorConstructor + add tests).

For rationale of changes, see https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces  We make use of it in our LoggingService.

Following passes on branch:
* `npm run test node`
* `npm run lint node`

# Standard stuff for all DefinitelyTyped PRs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.